### PR TITLE
Update invite link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,4 +20,4 @@ twitter:
   card: summary_large_image
   username: ruby-jp
 
-slack_invite_link: https://join.slack.com/t/ruby-jp/shared_invite/zt-1dtwm6asw-nySp8OsdZfKeowNOxKeyGQ
+slack_invite_link: https://join.slack.com/t/ruby-jp/shared_invite/zt-1h1wub6jl-s37DRnh3lPDeyCt5REr3Yw


### PR DESCRIPTION
「[ruby-jp.github.io](https://ruby-jp.github.io/) にある招待リンクが無効になっていて入れませんでした 😭 」という報告を受けたので更新してみました!

なお新しい招待リンクは次のように設定しています:

- 招待リンクの有効期限: 無期限
- 招待リンクの有効回数: 400回

NOTE: 401回目からは招待リンクを再度発行する必要がありそうです。