### PR TITLE
Translate ruby-jp landing page for English speakers

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,13 +24,25 @@
   <body>
     <header class="page-header" role="banner">
       <h1 class="project-name"><a href="/"><img class="page-header-logo" src="{{ '/assets/ruby-jp-white-big.svg?v=' | append: site.github.build_revision | relative_url }}" alt="{{ page.title | default: site.title | default: site.github.repository_name }}"></a></h1>
-			<h2 class="project-tagline">{{ page.title }}</h2>
-      <a href="{{ site.slack_invite_link }}" class="btn"><strong>ruby-jp Slack ワークスペースに参加する</strong></a>
+      <h2 class="project-tagline">{{ page.title }}</h2>
+      <a href="{{ site.slack_invite_link }}" class="btn"><strong>
+	{% if page.lang == 'en' %}
+	Join in ruby-jp Slack workspace
+	{% else %}
+	ruby-jp Slack ワークスペースに参加する
+	{% endif %}
+      </strong></a>
     </header>
     <main id="content" class="main-content" role="main">
       {{ content }}
       <footer class="site-footer">
-        <span class="site-footer-credits">ruby-jp は複数名の有志の Rubyist によって運営されています</span>
+        <span class="site-footer-credits">
+	  {% if page.lang == 'en' %}
+	  ruby-jp is organized by a group of volunteer Rubyists.
+	  {% else %}
+	  ruby-jp は複数名の有志の Rubyist によって運営されています
+	  {% endif %}
+	</span>
       </footer>
     </main>
   </body>

--- a/en/index.md
+++ b/en/index.md
@@ -29,28 +29,31 @@ ruby-jp is committed to providing a space where Ruby programmers, including lear
 - ソフトウェアの作者を含む \"他者へのリスペクトに欠けるような発言\" は控えましょう
 - 著しく問題がある行動が確認できた場合は、利用を停止することもありますのでご了承ください
 
-## 💎 ruby-jpの使い方 (To Be Translated)
+
+## 💎 ruby-jp usage
 {: #usage }
 
-- ruby-jp は参加者の技術レベルに関わらず、質問・相談・情報交換ができる場です
-- 過去ログをすべて読んで、場の空気を読む必要はありません
-- チャンネルの作成も絵文字の追加も、誰でも自由に行ってください。許可は不要です
-- 絵文字は著作権的に不適切なもの、他者を不快にさせるものは削除することがあります
-- 一定期間利用されていないチャンネルは、予告なくアーカイブすることがあります。もしも戻したい場合はいつでも戻してください
-- 過去ログは時間経過によって閲覧できなくなります
-- 情報量が多いので、ご自身の好きなチャンネルを購読しマイペースで楽しんでください
-- 趣味でプログラミングを楽しんでいる方や、異業種で Ruby を勉強したい方も大歓迎です
+- ruby-jp is a place where questions, discussions, and information exchanges can be held, regardless of participants' technical levels.
+- No need to read all past logs to post new topices.
+- Feel free to create channels and add emojis. No permission is required.
+- Emojis that are inappropriate in terms of copyright or likely to offend others may be removed.
+- Channels that have not been used for a certain period may be archived without notice. If you'd like them back, feel free to do so.
+- Past logs will become unviewable after a few months from posted.
+- Given the amount of information, please subscribe to channels of your interest and enjoy at your own pace.
+- Those who enjoy programming as a hobby or who want to study Ruby in different industries are also very welcome.
 
-## 🔰 Ruby入門者・学生の方へ (To Be Translated)
+
+## 🔰 For beginners
 {: #beginner }
 
-- いろいろなチャンネルがありますが `#newbie` という初学者用のチャンネル、 `#students` という学生向けのチャンネルがおすすめです
-- Ruby on Railsやデータベースの質問も大歓迎です
-- オンラインのプログラミング学習コースや参考書で遭遇した不明点や学習方法など、何でも気軽に聞いてください
-- どのチャンネルに質問して良いか分からなければ、まず `#newbie` や `#support` で質問してみると良いでしょう。多くの人が見ていますし、より適切なチャンネルがあれば誰かがリンクを貼ってくれます
+- We have various channels, but we recommend `#newbie` for beginners and `#students` for student-oriented discussions.
+- Questions about Ruby on Rails and databases are also very welcome.
+- If you encounter any points of confusion in online programming courses or textbooks, or have questions about how to learn, feel free to ask anything.
+- If you're not sure which channel to ask your question in, start with `#newbie` or `#support` channels. Many people are watching, and if there's a more suitable channel, someone will provide a link.
 
-## 🙌 自己紹介をしましょう (To Be Translated)
+
+## 🙌 Self-introduction
 {: #self-introduction }
 
-- `#general` チャンネルで**自己紹介**をしましょう
-- **プロフィール画像**を設定しましょう。覚えてもらいやすいので便利です
+- **Let's introduce yourself** in the `#general` channel after joining!
+- **Set a profile picture.** It makes it easier for others to remember you.

--- a/en/index.md
+++ b/en/index.md
@@ -1,0 +1,56 @@
+---
+layout: default
+image: /assets/ogp.png
+title: ruby-jp.slack.com
+lang: en
+---
+
+**ruby-jp is a Slack workspace created with the intention of fostering interactions between Ruby programmers.**
+
+Regardless of technical proficiency, we aim to provide a space where questions, consultations, and information exchange can be carried out with ease.
+
+**We warmly welcome beginners and students** like studying Ruby. No professional experiences required!
+
+If you are studying and want advice from experienced members, or if you're having trouble with anything, don't hesitate to ask us anytime.
+
+Please make sure to read the following [Code of Conduct](#code-of-conduct) before joining in.
+
+ruby-jp is committed to providing a space where Ruby programmers, including learners of course, can communicate with each other beyond generations and corporate boundaries.
+
+
+---
+
+## 🌱 行動規範 (To Be Translated)
+{: #code-of-conduct }
+
+- 上級者は、入門者や学習者にやさしく接するようにしてください
+- 議論が白熱しても、相手を罵ったり傷つけることがないようにしてください
+- 性別/性的指向/障碍の有無/人種/宗教に関わりなく、誰もが気持ちよく交流できるようにしましょう
+- ソフトウェアの作者を含む \"他者へのリスペクトに欠けるような発言\" は控えましょう
+- 著しく問題がある行動が確認できた場合は、利用を停止することもありますのでご了承ください
+
+## 💎 ruby-jpの使い方 (To Be Translated)
+{: #usage }
+
+- ruby-jp は参加者の技術レベルに関わらず、質問・相談・情報交換ができる場です
+- 過去ログをすべて読んで、場の空気を読む必要はありません
+- チャンネルの作成も絵文字の追加も、誰でも自由に行ってください。許可は不要です
+- 絵文字は著作権的に不適切なもの、他者を不快にさせるものは削除することがあります
+- 一定期間利用されていないチャンネルは、予告なくアーカイブすることがあります。もしも戻したい場合はいつでも戻してください
+- 過去ログは時間経過によって閲覧できなくなります
+- 情報量が多いので、ご自身の好きなチャンネルを購読しマイペースで楽しんでください
+- 趣味でプログラミングを楽しんでいる方や、異業種で Ruby を勉強したい方も大歓迎です
+
+## 🔰 Ruby入門者・学生の方へ (To Be Translated)
+{: #beginner }
+
+- いろいろなチャンネルがありますが `#newbie` という初学者用のチャンネル、 `#students` という学生向けのチャンネルがおすすめです
+- Ruby on Railsやデータベースの質問も大歓迎です
+- オンラインのプログラミング学習コースや参考書で遭遇した不明点や学習方法など、何でも気軽に聞いてください
+- どのチャンネルに質問して良いか分からなければ、まず `#newbie` や `#support` で質問してみると良いでしょう。多くの人が見ていますし、より適切なチャンネルがあれば誰かがリンクを貼ってくれます
+
+## 🙌 自己紹介をしましょう (To Be Translated)
+{: #self-introduction }
+
+- `#general` チャンネルで**自己紹介**をしましょう
+- **プロフィール画像**を設定しましょう。覚えてもらいやすいので便利です


### PR DESCRIPTION
ruby-lang と同様に `/en` というページを作成し、とりあえず概要部分 + header/footer 部分を英語にしました! 📝 💨 

Mark as `To Be Translated` for the rest of sections that should be translated later by another PR:
- [ ] ~~🌱 行動規範 (To Be Translated)~~ -> Once this PR merged, translate this later.
- [x] 💎 ruby-jpの使い方 (To Be Translated)
- [x] 🔰 Ruby入門者・学生の方へ (To Be Translated)
- [x] 🙌 自己紹介をしましょう (To Be Translated)

This PR focuses on creating an English landing page and sections other than `🌱 行動規範`, which might be translated more carefully, so planning to start translating it after merging this PR.

## Screenshot of /en page

<img width="859" alt="image" src="https://github.com/ruby-jp/ruby-jp.github.io/assets/155807/be0c9dc9-b70c-44e5-8536-b5dea724ba48">
<img width="856" alt="image" src="https://github.com/ruby-jp/ruby-jp.github.io/assets/155807/9e727e75-c1af-464d-b6d6-210d4befd48c">
