### PR TITLE
Use English description for English landing page 

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,6 +12,10 @@
     {% endif %}
     <meta charset="UTF-8">
 {% seo %}
+    {% if page.description %}
+    <meta name="description" content="{{ page.description }}">
+    <meta property="og:description" content="{{ page.description }}">
+    {% endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#b41d23">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/en/index.md
+++ b/en/index.md
@@ -2,6 +2,7 @@
 layout: default
 image: /assets/ogp.png
 title: ruby-jp.slack.com
+description: ruby-jp is a Slack workspace created with the intention of fostering interactions between Ruby programmers. Regardless of technical proficiency, we aim to provide a space where questions, consultations, and information exchange can be carried out with ease.
 lang: en
 ---
 


### PR DESCRIPTION
Translate a missing meta tag of `description` in #33, which helps to share more friendly in English.

## Before/After when posted https://ruby-jp.github.io/en in Slack
<img width="462" alt="image" src="https://github.com/ruby-jp/ruby-jp.github.io/assets/155807/71c44155-c022-4337-b159-1cb67eae472e">

<img width="437" alt="image" src="https://github.com/ruby-jp/ruby-jp.github.io/assets/155807/1a2a31e0-e538-4ffa-9edd-bb3f1e664065">
