### PR TITLE
Update slack invitation link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,4 +20,4 @@ twitter:
   card: summary_large_image
   username: ruby-jp
 
-slack_invite_link: https://join.slack.com/t/ruby-jp/shared_invite/zt-1h1wub6jl-s37DRnh3lPDeyCt5REr3Yw
+slack_invite_link: https://join.slack.com/t/ruby-jp/shared_invite/zt-1x6ih6re9-rb_RdylYdnqrVplw278n4Q


### PR DESCRIPTION
The URL of current slack invitation is expired.